### PR TITLE
Add X and Bluesky links to header

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -34,3 +34,15 @@
   pre = "linkedin"
   url = "https://www.linkedin.com/in/sean-t-allen-has-a-posse/"
   weight = 70
+
+[[main]]
+  identifier = "x-twitter"
+  pre = "x-twitter"
+  url = "https://x.com/seantallen"
+  weight = 80
+
+[[main]]
+  identifier = "bluesky"
+  pre = "bluesky"
+  url = "https://bsky.app/profile/seantallen.bsky.social"
+  weight = 90


### PR DESCRIPTION
Adds header menu entries for x.com/seantallen and bsky.app/profile/seantallen.bsky.social alongside the existing GitHub and LinkedIn icons.