### PR TITLE
Add RSS link to header menu

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -46,3 +46,9 @@
   pre = "bluesky"
   url = "https://bsky.app/profile/seantallen.bsky.social"
   weight = 90
+
+[[main]]
+  identifier = "rss"
+  pre = "rss"
+  url = "/index.xml"
+  weight = 100


### PR DESCRIPTION
Adds an RSS icon to the main menu, positioned immediately to the left of the dark mode toggle on desktop (and in the same spot in the mobile menu). Links to `/index.xml`, the home feed that covers all `mainSections`.

Auto-discovery via `<link rel="alternate">` already works — Blowfish emits it from `head.html`. The explicit link is for readers who don't know to check, or who want to copy-paste the feed URL.