### PR TITLE
Add Lorin Hochstein's blog to GC Made Fast links

### DIFF
--- a/content/talks/gc-made-fast/index.md
+++ b/content/talks/gc-made-fast/index.md
@@ -22,6 +22,7 @@ This isn't magic and it isn't free. But the costs are local, not coordination co
 ## Links
 
 * [Pony](https://www.ponylang.io/)
+* [Lorin Hochstein](http://surfingcomplexity.blog/)
 
 ## References
 


### PR DESCRIPTION
Adds Lorin Hochstein's Surfing Complexity blog to the Links section of the GC Made Fast talk page.