### PR TITLE
Switch homepage recent list from fixed count to 6-month window

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -20,7 +20,8 @@ mainSections = ["posts", "talks", "interviews", "panels", "papers"]
   layout = "hero"
   homepageImage = "img/homepage.png"
   showRecent = true
-  showRecentItems = 10
+  recentMonths = 6
+  recentMinimum = 10
 
 [article]
   showHero = true

--- a/layouts/partials/recent-articles/list.html
+++ b/layouts/partials/recent-articles/list.html
@@ -1,0 +1,15 @@
+{{ $minimum := .Site.Params.homepage.recentMinimum | default 10 }}
+{{ $months := .Site.Params.homepage.recentMonths | default 6 }}
+{{ $cutoff := now.AddDate 0 (sub 0 $months) 0 }}
+{{ $allPages := where .Site.RegularPages "Type" "in" .Site.Params.mainSections }}
+{{ $windowed := where $allPages "Date" "ge" $cutoff }}
+{{ $pages := $windowed }}
+{{ if lt (len $windowed) $minimum }}
+  {{ $pages = first $minimum $allPages }}
+{{ end }}
+
+<section class="space-y-10 w-full">
+  {{ range $pages }}
+    {{ partial "article-link/simple.html" . }}
+  {{ end }}
+</section>


### PR DESCRIPTION
Previously the homepage showed a fixed 10 most recent posts. It now shows everything from the last 6 months with a floor of 10 — so the count grows with posting activity but never falls below the original behavior. Window and floor are configurable via `recentMonths` and `recentMinimum` under `[homepage]` in `params.toml`.

Implementation overrides the theme's `layouts/partials/recent-articles/list.html` so we don't fork the rest of the recent-articles machinery. The override drops the theme's `.Paginate` call (the homepage isn't paginated) and filters by `Date >= now - recentMonths`.

At time of writing (2026-05-07), the window is producing 14 items (12 posts, 1 talk, 1 interview).