### PR TITLE
Tag 'GitHub Is a Gift' as Oral Histories

### DIFF
--- a/content/posts/github-is-a-gift/index.md
+++ b/content/posts/github-is-a-gift/index.md
@@ -3,7 +3,7 @@ title: "GitHub Is a Gift"
 slug: "github-is-a-gift"
 date: "2026-06-23T16:00:00-04:00"
 draft: false
-tags: ["Stories"]
+tags: ["Oral Histories"]
 description: "GitHub has taken a beating lately, but I'm old enough to remember when open source developers scrounged for the machines to test their code. From there, free CI looks like a gift."
 summary: "I remember the before times."
 imagePosition: "center 25%"


### PR DESCRIPTION
Recategorizes "GitHub Is a Gift" under a new **Oral Histories** tag — a first-person witness account of how the open-source world actually was in the before times — replacing the broader `Stories` tag.

A survey of the other posts turned up no clear oral histories. The one borderline case is "Of Debt and Decisions" (a sustained recollection of 1990s shrinkwrap-software engineering, but framed as a technical-debt argument); it's left out pending a call on whether it belongs in the bucket.
